### PR TITLE
Fixed broken Resources links on ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,5 +87,5 @@ Slides for this workshop is located ![here]().
 - Run terraform apply
 
 ## 📑 Resources
-* ![Terraform Tutorial](https://spacelift.io/blog/terraform-tutorial)
-* ![Docker Tutorial For Beginners](https://www.youtube.com/watch?v=fqMOX6JJhGo)
+* [Terraform Tutorial](https://spacelift.io/blog/terraform-tutorial)
+* [Docker Tutorial For Beginners](https://www.youtube.com/watch?v=fqMOX6JJhGo)


### PR DESCRIPTION
The [Resources links](https://github.com/thestrugglingblack/the-docker-playbook#-resources) links were built, but a `!` prefix prevented them from rendering.